### PR TITLE
Ajout resize fenetre lors de fin de partie

### DIFF
--- a/src/Gtk/Menu.rb
+++ b/src/Gtk/Menu.rb
@@ -53,6 +53,7 @@ class Menu
 
 		fenetre.add(vbox)
 		fenetre.show_all
+		fenetre.reshow_with_initial_size
 	end
 
 end # Marqueur de fin de classe


### PR DESCRIPTION
La ligne fenetre.show_all est peut être rendue redondante par fenetre.reshow_with_initial_size ?
Il faudra mettre ça chaque fois que la fenetre peut réduire de taille
